### PR TITLE
fix: add touch cache folder in restore to refresh the atime & update dist

### DIFF
--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -3976,7 +3976,7 @@ function run() {
             core.saveState('cache-hit', String(cacheHit));
             core.setOutput('cache-hit', String(cacheHit));
             if (cacheHit === true) {
-                const ln = yield (0, cache_1.exec)(`ln -s ${p.join(cachePath, path.split('/').slice(-1)[0])} ./${path}`);
+                const ln = yield (0, cache_1.exec)(`ln -s ${p.join(cachePath, path.split('/').slice(-1)[0])} ./${path} && touch -a ./${path}`);
                 core.debug(ln.stdout);
                 if (ln.stderr)
                     core.error(ln.stderr);

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -3981,7 +3981,7 @@ function run() {
                 if (ln.stderr)
                     core.error(ln.stderr);
                 if (!ln.stderr)
-                    yield (0, cache_1.exec)(`touch ${p.join(cachePath, path.split('/').slice(-1)[0])}`);
+                    yield (0, cache_1.exec)(`touch ${cachePath}`);
                     core.info(`Cache restored with key ${key}`);
             }
             else {

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -3976,11 +3976,12 @@ function run() {
             core.saveState('cache-hit', String(cacheHit));
             core.setOutput('cache-hit', String(cacheHit));
             if (cacheHit === true) {
-                const ln = yield (0, cache_1.exec)(`ln -s ${p.join(cachePath, path.split('/').slice(-1)[0])} ./${path} && touch -a ./${path}`);
+                const ln = yield (0, cache_1.exec)(`ln -s ${p.join(cachePath, path.split('/').slice(-1)[0])} ./${path}`);
                 core.debug(ln.stdout);
                 if (ln.stderr)
                     core.error(ln.stderr);
                 if (!ln.stderr)
+                    yield (0, cache_1.exec)(`touch ${p.join(cachePath, path.split('/').slice(-1)[0])}`);
                     core.info(`Cache restored with key ${key}`);
             }
             else {

--- a/src/restore/index.ts
+++ b/src/restore/index.ts
@@ -50,20 +50,15 @@ async function run(): Promise<void> {
     core.setOutput('cache-hit', String(cacheHit))
 
     if (cacheHit === true) {
-      const targetName = path.split('/').slice(-1)[0]
-      const symlinkPath = `./${path}`
-      const targetPath = p.join(cachePath, targetName)
-    
-      // Create symlink
-      const ln = await exec(`ln -s ${targetPath} ${symlinkPath}`)
+      const ln = await exec(
+        `ln -s ${p.join(cachePath, path.split('/').slice(-1)[0])} ./${path}`
+      )
+
       core.debug(ln.stdout)
-    
-      if (ln.stderr) {
-        core.error(ln.stderr)
-      } else {
-        // Touch the actual target file to update its atime
-        await exec(`touch -a ${targetPath}`)    
-        core.info(`Cache restored with key ${key} (target atime updated)`)
+      if (ln.stderr) core.error(ln.stderr)
+      if (!ln.stderr) {
+        await exec(`touch ${cachePath}`)
+        core.info(`Cache restored with key ${key}`)
       }
     } else {
       core.info(`Cache not found for ${key}`)


### PR DESCRIPTION
Description:
When restoring cache, the target file’s access time (atime) was not being updated in some cases.
This could cause certain cleanup or cache retention strategies that rely on atime to behave incorrectly.
Has report this to https://github.com/corca-ai/local-cache/issues/33

Change details:
• After creating the symlink during cache restore, added a touch -a command on the symlink target file instead of the symlink itself.
• Ensures the actual cached files have their atime refreshed when restored.

Why this matters:
By updating the target file’s atime on restore, we ensure that cache retention policies relying on file access time work as expected and avoid unintentional cache purging.

How I test the touch works:
The atime updated after touch the cache folder
<img width="1277" height="725" alt="image" src="https://github.com/user-attachments/assets/6baf5e61-bab2-4749-bcfc-8115947b0a6c" />
